### PR TITLE
Add functionality to manage ticket admins for check-ins

### DIFF
--- a/src/facets/TicketCheckInFacet.sol
+++ b/src/facets/TicketCheckInFacet.sol
@@ -25,4 +25,12 @@ contract TicketCheckInFacet {
     function checkInTicket(uint256 _ticketId, address _ticketOwner, uint256 _tokenId) external payable {
         _ticketId._checkInTicket(_ticketOwner, _tokenId);
     }
+
+    function addTicketAdmins(uint256 _ticketId, address[] memory _admins) external payable {
+        _ticketId._addTicketAdmins(_admins);
+    }
+
+    function removeTicketAdmins(uint256 _ticketId, address[] memory _admins) external payable {
+        _ticketId._removeTicketAdmins(_admins);
+    }
 }

--- a/src/libraries/errors/TicketErrors.sol
+++ b/src/libraries/errors/TicketErrors.sol
@@ -36,3 +36,5 @@ error WithdrawFailed(FeeType feeType);
 error NotTicketOwner(uint256 tokenId);
 // Custom error for invalid token address
 error InvalidTokenAddress();
+error NoAdmins();
+error InvalidAdminAddress();


### PR DESCRIPTION
Introduce functions to add and remove ticket admins, enhancing the management of ticket check-ins. Include error handling for invalid admin addresses and cases with no admins provided.